### PR TITLE
Fix export report filter with duplicated summed values

### DIFF
--- a/stock/views.py
+++ b/stock/views.py
@@ -9582,7 +9582,10 @@ def exportExcelSummaryByDistributorFrequently(request):
         my_q &= Q(branch_company__code__in=company_in)
 
     # ---------------- BASE QUERY ----------------
-    base_qs = PurchaseOrder.objects.filter(my_q)
+    # ใช้ id__in เพื่อตัด join กับ purchaseorderitem (เช่นตอนกรอง category)
+    # ออกจาก queryset ที่ใช้ Sum ป้องกันค่าถูกคูณซ้ำตามจำนวนรายการสินค้า
+    po_ids = PurchaseOrder.objects.filter(my_q).values_list('id', flat=True).distinct()
+    base_qs = PurchaseOrder.objects.filter(id__in=po_ids)
 
     # ---------------- SUBQUERY (ITEM) ----------------
     item_sub = PurchaseOrderItem.objects.filter(


### PR DESCRIPTION
## Summary
- Excel export summary by distributor frequently was double-counting sums when the item/category filter caused a join with purchaseorderitem, multiplying PurchaseOrder rows.
- Fixed by pre-resolving distinct PurchaseOrder ids before applying the aggregate query.

## Test plan
- [x] `python manage.py test stock` passes (3/3)