### PR TITLE
fix bug error 'module' in วันที่รับสินค้า (autoUploadeRecive)

### DIFF
--- a/stock/views.py
+++ b/stock/views.py
@@ -9670,7 +9670,7 @@ def autoUploadeRecive(request):
     if not branch or not branch.affiliated:
         return redirect('viewReceive')
 
-    start_date = datetime(2026, 1, 1)
+    start_date = datetime.datetime(2026, 1, 1)
 
     all_po = PurchaseOrder.objects.filter(
         approver_status_id=2,


### PR DESCRIPTION
## Summary
- Fixes a `'module' object is not callable` bug in `autoUploadeRecive` where `datetime(2026, 1, 1)` was called directly instead of `datetime.datetime(2026, 1, 1)`.

## Test plan
- [x] `python manage.py test stock` — 3 tests pass