### PR TITLE
ใบเปรียบและใบสั่ง ตรงรายละเอียดสินค้า ให้แถวใหม่ได้

### DIFF
--- a/stock/forms.py
+++ b/stock/forms.py
@@ -266,6 +266,7 @@ PurchaseOrderItemModelFormset = modelformset_factory(
         'unit_price': forms.NumberInput(attrs={'size': 3 ,'class': 'form-control unit-price text-right'}),
         'discount': forms.TextInput(attrs={'placeholder':'0.00 ', 'class': 'form-control discount text-right'}),
         'price': forms.NumberInput(attrs={'size': 3 ,'class': 'form-control price text-right'}),
+        'description': forms.Textarea(attrs={'rows': 1}),
     }
 )
 
@@ -281,6 +282,7 @@ PurchaseOrderItemInlineFormset = inlineformset_factory(
         'unit_price': forms.NumberInput(attrs={'size': 3 ,'class': 'form-control unit-price text-right'}),
         'discount': forms.TextInput(attrs={'placeholder':'0.00 ', 'class': 'form-control discount text-right'}),
         'price': forms.NumberInput(attrs={'size': 3 ,'class': 'form-control price text-right'}),
+        'description': forms.Textarea(attrs={'rows': 1}),
     }
     , can_delete=True
 )
@@ -425,6 +427,7 @@ CPitemFormset = modelformset_factory(
         'unit_price': forms.NumberInput(attrs={}),
         'discount': forms.TextInput(attrs={'placeholder':'0.00'}),
         'price': forms.NumberInput(attrs={}),
+        'description': forms.Textarea(attrs={'rows': 1}),
     },
     labels = {
         'item': _('สินค้า'),
@@ -443,6 +446,7 @@ CPitemInlineFormset = inlineformset_factory(
         'unit_price': forms.NumberInput(attrs={}),
         'discount': forms.TextInput(attrs={'placeholder':'0.00'}),
         'price': forms.NumberInput(attrs={}),
+        'description': forms.Textarea(attrs={'rows': 1}),
     },
     labels = {
         'item': _('สินค้า'),

--- a/stock/templates/comparePricePO/printComparePricePO.html
+++ b/stock/templates/comparePricePO/printComparePricePO.html
@@ -157,7 +157,7 @@
             {% for oldest in items_oldest %}
                 <tr>
                     <th scope="row" class="text-center">{{forloop.counter}}</th>
-                    <td>{{oldest.item.product_name}} <b class="text-success">{{oldest.description}}</b></td>
+                    <td>{{oldest.item.product_name}} <b class="text-success" style="white-space: pre-line;">{{oldest.description|linebreaksbr}}</b></td>
                     <td class="text-right">{{oldest.quantity |floatformat:"-4"}}</td>
                     <td class="text-center">{{oldest.unit}}</td>
                         {% for it in itemName %}

--- a/stock/templates/comparePricePO/showComparePricePO.html
+++ b/stock/templates/comparePricePO/showComparePricePO.html
@@ -176,7 +176,7 @@
             {% for oldest in items_oldest %}
                 <tr>
                     <th scope="row" class="text-center">{{forloop.counter}}</th>
-                    <td>{{oldest.item.product_name}} <b class="text-success">{{oldest.description}}</b></td>
+                    <td>{{oldest.item.product_name}} <b class="text-success" style="white-space: pre-line;">{{oldest.description|linebreaksbr}}</b></td>
                     <td class="text-right">{{oldest.quantity |floatformat:"-4"}}</td>
                     <td class="text-center">{{oldest.unit}}</td>
                         {% for it in itemName %}

--- a/stock/templates/comparePricePOApprove/printCPApprove.html
+++ b/stock/templates/comparePricePOApprove/printCPApprove.html
@@ -168,7 +168,7 @@
             {% for oldest in items_oldest %}
                 <tr>
                     <th scope="row" class="text-center">{{forloop.counter}}</th>
-                    <td>{{oldest.item.product_name}} <b class="text-success">{{oldest.description}}</b></td>
+                    <td>{{oldest.item.product_name}} <b class="text-success" style="white-space: pre-line;">{{oldest.description|linebreaksbr}}</b></td>
                     <td class="text-right">{{oldest.quantity |floatformat:"-4"}}</td>
                     <td class="text-center">{{oldest.unit}}</td>
                         {% for it in itemName %}

--- a/stock/templates/comparePricePOItem/createComparePricePOItem.html
+++ b/stock/templates/comparePricePOItem/createComparePricePOItem.html
@@ -79,7 +79,7 @@
                 <li class="list-group-item">
                     <div class="row">
                         <div class="col-2">{% if it.item %}{{it.item.product_name}}{% endif %}</div>
-                        <div class="col">{% if it.description %}{{it.description}}{% endif %}</div>
+                        <div class="col">{% if it.description %}{{it.description|linebreaksbr}}{% endif %}</div>
                         <div class="col">{% if it.quantity %}{{it.quantity}}{% endif %}</div>
                         <div class="col">{% if it.unit %}{{it.unit}}{% endif %}</div>
                         <div class="col">{% if it.brand %}{{it.brand}}{% endif %}</div>
@@ -352,7 +352,7 @@ $(function() {
     "{% for it in cp_item %}"
         "{% if it.bidder.id == bidder_oldest %}"
             $("#id_form-{{forloop.counter0}}-item").val("{{it.item.id}}");
-            $("#id_form-{{forloop.counter0}}-description").val("{{it.description}}");
+            $("#id_form-{{forloop.counter0}}-description").val("{{it.description|escapejs}}");
             $("#id_form-{{forloop.counter0}}-quantity").val("{{it.quantity}}");
             $("#id_form-{{forloop.counter0}}-oldquantity").val("{{it.quantity}}");
             $("#id_form-{{forloop.counter0}}-unit").val("{{it.unit.id}}");

--- a/stock/templates/comparePricePOItem/editComparePricePOItem.html
+++ b/stock/templates/comparePricePOItem/editComparePricePOItem.html
@@ -70,7 +70,7 @@
                 <li class="list-group-item">
                     <div class="row">
                         <div class="col-2">{% if it.item %}{{it.item.product_name}}{% endif %}</div>
-                        <div class="col">{% if it.description %}{{it.description}}{% endif %}</div>
+                        <div class="col">{% if it.description %}{{it.description|linebreaksbr}}{% endif %}</div>
                         <div class="col">{% if it.quantity %}{{it.quantity}}{% endif %}</div>
                         <div class="col">{% if it.unit %}{{it.unit}}{% endif %}</div>
                         <div class="col">{% if it.brand %}{{it.brand}}{% endif %}</div>
@@ -192,7 +192,7 @@
                                   <option data-id="{{results.item__id}}" data-show="{{results.item__product__id}} {{results.item__product_name}}" data-refno = "{{results.item__requisit__pr_ref_no}}{{results.item__product__id}}" value="{{results.item__product__id}}: {{results.item__product_name}} เลขที่ {{results.item__requisit__pr_ref_no}}" data-quantity="{{results.item__quantity_pr}}" data-unit="{{results.item__product__unit__id}}"></option>
                                 {% endfor %}
                             </datalist>
-                            {{form.description | add_class:"form-control"}}
+                            {{form.description | add_class:"form-control description"}}
                             {{form.quantity | add_class:"form-control quantity"}}
                             {{form.unit | add_class:"form-control"|attr:"required:true"}}
                             {{form.brand | add_class:"form-control"}}

--- a/stock/templates/comparePricePOItem/editComparePricePOItemFromPR.html
+++ b/stock/templates/comparePricePOItem/editComparePricePOItemFromPR.html
@@ -116,7 +116,7 @@
                                   <option data-id="{{results.item__id}}" data-show="{{results.item__product__id}} {{results.item__product_name}}" data-refno = "{{results.item__requisit__pr_ref_no}}{{results.item__product__id}}" value="{{results.item__product__id}}: {{results.item__product_name}} เลขที่ {{results.item__requisit__pr_ref_no}}" data-quantity="{{results.quantity}}" data-unit="{{results.unit__id}}"></option>
                                 {% endfor %}
                             </datalist>
-                            {{form.description | add_class:"form-control"}}
+                            {{form.description | add_class:"form-control description"}}
                             {{form.quantity | add_class:"form-control quantity"}}
                             {{form.unit | add_class:"form-control"|attr:"required:true"}}
                             {{form.brand | add_class:"form-control"}}

--- a/stock/templates/purchaseOrder/showPO.html
+++ b/stock/templates/purchaseOrder/showPO.html
@@ -193,7 +193,7 @@
                         {% for item in items %}
                         <tr>
                             <td class="text-center">{{ forloop.counter }}</td>
-                            <td>{{ item.item.product.id }} {{ item.item.product_name }} <b class="text-success">{{ item.description }}</b></td>
+                            <td>{{ item.item.product.id }} {{ item.item.product_name }} <b class="text-success" style="white-space: pre-line;">{{ item.description|linebreaksbr }}</b></td>
                             <td class="text-right">{{ item.quantity |floatformat:"-4"}}</td>
                             <td class="text-center">{{ item.unit}}</td>
                             <td class="text-right">{{ item.unit_price | intcomma}}</td>

--- a/stock/templates/purchaseOrderApprove/editPOApprove.html
+++ b/stock/templates/purchaseOrderApprove/editPOApprove.html
@@ -148,7 +148,7 @@
                         {% for item in items %}
                         <tr>
                             <td class="text-center">{{ forloop.counter }}</td>
-                            <td>{{ item.item.product.id}} {{ item.item.product_name }} <b class="text-success">{{ item.description }}</b></td>
+                            <td>{{ item.item.product.id}} {{ item.item.product_name }} <b class="text-success" style="white-space: pre-line;">{{ item.description|linebreaksbr }}</b></td>
                             <td class="text-right">{{ item.quantity |floatformat:"-4"}}</td>
                             <td class="text-center">{{ item.unit}}</td>
                             <td class="text-right">{{ item.unit_price | intcomma}}</td>

--- a/stock/templates/purchaseOrderItem/createPOItem.html
+++ b/stock/templates/purchaseOrderItem/createPOItem.html
@@ -88,7 +88,7 @@
                               <option data-id="{{results.id}}" data-show="{{results.product.id}} {{results.product}}" data-refno = "{{results.requisit.pr_ref_no}}{{results.product.id}}" value="{{results.product.id}}: {{results.product}} เลขที่ {{results.requisit.pr_ref_no}}" data-quantity="{{results.quantity_pr}}" data-unit="{{results.product.unit.id}}"></option>
                             {% endfor %}
                           </datalist>
-                          {{form.quantity}} {{form.unit | add_class:"form-control"}} {{form.unit_price}} {{form.price}}
+                          {{form.description | add_class:"form-control description"}} {{form.quantity}} {{form.unit | add_class:"form-control"}} {{form.unit_price}} {{form.price}}
                           <div class="input-group-append text-right">
                               <button class="btn btn-success add-form-row hidden-print">+</button>
                           </div>

--- a/stock/templates/purchaseOrderItem/createPOItemFromComparisonPrice.html
+++ b/stock/templates/purchaseOrderItem/createPOItemFromComparisonPrice.html
@@ -266,7 +266,7 @@ for (let i = 1; i < len; i++) {
 //set ค่าตามผู้จำหน่ายแรกสุดที่ได้สร้าง
 "{% for it in cp_item %}"
         $("#id_form-{{forloop.counter0}}-item").val("{{it.item.id}}");
-        $("#id_form-{{forloop.counter0}}-description").val("{{it.description}}");
+        $("#id_form-{{forloop.counter0}}-description").val("{{it.description|escapejs}}");
         $("#id_form-{{forloop.counter0}}-quantity").val("{{it.quantity}}");
         $("#id_form-{{forloop.counter0}}-oldquantity").val("{{it.quantity}}");
         $("#id_form-{{forloop.counter0}}-unit").val("{{it.unit.id}}");

--- a/stock/templates/purchaseOrderItem/editPOItem.html
+++ b/stock/templates/purchaseOrderItem/editPOItem.html
@@ -180,7 +180,7 @@
                             <option data-id="{{results.item__id}}" data-show="{{results.item__product__id}} {{results.item__product_name}}" data-refno = "{{results.item__requisit__pr_ref_no}}{{results.item__product__id}}" value="{{results.item__product__id}}: {{results.item__product_name}} เลขที่ {{results.item__requisit__pr_ref_no}}" data-quantity="{{results.item__quantity_pr}}" data-unit="{{results.unit__id}}" data-remain="{{results.q_remain}}" data-used="{{results.item__quantity_used}}" data-cp="{{results.po__cp}}"></option>
                           {% endfor %}
                         </datalist>
-                        {{form.description|add_class:"form-control"}} {{form.quantity }} {{form.unit| add_class:"form-control" |attr:"required:true"}} {{form.unit_price}}  {{form.discount}} {{form.price}} {{ form.DELETE| add_class:"del"}}
+                        {{form.description|add_class:"form-control description"}} {{form.quantity }} {{form.unit| add_class:"form-control" |attr:"required:true"}} {{form.unit_price}}  {{form.discount}} {{form.price}} {{ form.DELETE| add_class:"del"}}
                         {% if form.id.value %}
                           <div class="input-group-append text-right">
                             <button type="button" class="btn btn-danger hidden-print" onclick="hideDiv('{{form.id.value}}')">-</button>


### PR DESCRIPTION
## สรุป
- ปรับให้ช่องรายละเอียดสินค้าในใบเปรียบราคาและใบสั่งซื้อ ขึ้นบรรทัดใหม่ได้ (multi-line)
- แก้ไข template ที่เกี่ยวข้องให้แสดงผลข้อความหลายบรรทัดถูกต้อง

## Test
- `python manage.py test stock` — ผ่านทั้งหมด 10 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)