### PR TITLE
ปรับหน้า view all detail ให้โหลดเร็วขึ้น

### DIFF
--- a/stock/context_processors.py
+++ b/stock/context_processors.py
@@ -6,11 +6,40 @@ from django.db import connection
 from collections import Counter
 from django.contrib.auth.decorators import login_required
 
+_NO_PROFILE = object()
+
+
+def _user_profile(request):
+    """The request user's UserProfile, fetched at most once per request.
+
+    Nearly every context processor below needs it, and they all run on every
+    page render — findAllApproveAlert alone is invoked once per company tab —
+    so without memoisation a single page issued ~40 identical UserProfile
+    queries. The row cannot change midway through a request, so caching it on
+    the request object is behaviour-neutral.
+
+    Raises UserProfile.DoesNotExist exactly like the .get() it replaces (and
+    caches that outcome too), so the surrounding try/except blocks at every
+    call site keep behaving as before.
+    """
+    cached = getattr(request, '_stock_user_profile_cache', None)
+    if cached is None:
+        try:
+            cached = UserProfile.objects.get(user_id=request.user.id)
+        except UserProfile.DoesNotExist:
+            cached = _NO_PROFILE
+        request._stock_user_profile_cache = cached
+    if cached is _NO_PROFILE:
+        raise UserProfile.DoesNotExist(
+            'UserProfile matching query does not exist.')
+    return cached
+
+
 def findCompanyIn(request):
     active = request.session.get('company_code', 'ALL')
     #หาหน้าต่างการมองเห็นบริษัททั้งหมดของ user
     try:
-        user_profile = UserProfile.objects.get(user = request.user.id)
+        user_profile = _user_profile(request)
         company_all = BaseBranchCompany.objects.filter(userprofile = user_profile).values('code')
     except:
         company_all = ""
@@ -24,7 +53,7 @@ def findCompanyIn(request):
 
 def userVisibleTab(request):
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
         visible_tab = BaseVisible.objects.filter(userprofile = user_profile)
     except:
         visible_tab = None
@@ -36,7 +65,7 @@ def companyVisibleTab(request):
     global_notification_badge_count = 0
     try:
         if request.user.is_authenticated:
-            user_profile = UserProfile.objects.get(user_id = request.user.id)
+            user_profile = _user_profile(request)
             company_tab = BaseBranchCompany.objects.filter(userprofile = user_profile)
             company_code = BaseBranchCompany.objects.filter(userprofile = user_profile).values('code')
 
@@ -110,7 +139,7 @@ def approvePendingCounter(request):
 
     #ใบขอซื้อ
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
 
         permiss = BasePermission.objects.filter(codename ='CAAPR')
         isPermiss_pr = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename='CAAPR', branch_company__code__in = company_in).values('branch_company__code')
@@ -175,7 +204,7 @@ def approvePOCounter(request):
     po_count = 0
     #get permission with position login
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
 
         permiss = BasePermission.objects.filter(codename ='CAAPO')
         isPermiss = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename='CAAPO', branch_company__code__in = company_in).values('branch_company__code')
@@ -264,7 +293,7 @@ def approveCPAllCounter(request):
     ''' สิทธิใบเปรียบเทียบแบบเก่าเปลี่ยนเป็นแบบ fix ชื่อ
     #ผู้ตรวจสอบ
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
         permiss = BasePermission.objects.filter(codename__in= ['CAECP1','CAECP2','CAECP3','CAECP4','CAECPD','CAECPA'])
         isPermissAE = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename__in= ['CAECP1','CAECP2','CAECP3','CAECP4','CAECPD','CAECPA']).prefetch_related(Prefetch('base_permission', queryset=permiss)).values('base_permission')
     except:
@@ -384,7 +413,7 @@ def approveCPAllCounter(request):
 
     #ถ้าเป็นผู้อนุมัติพิเศษ ใบเปรียบเทียบ
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
 
         permiss = BasePermission.objects.filter(codename ='CASCP')
         isPermiss_scp = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename='CASCP', branch_company__code__in = company_in).values('branch_company__code', 'base_permission')
@@ -720,7 +749,7 @@ def findAllApproveAlert(request, tab):
 
     #get permission with position login
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
 
         permiss = BasePermission.objects.filter(codename ='CAAPR')
         isPermiss = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename='CAAPR', branch_company__code__in = tab).values('branch_company__code')
@@ -754,7 +783,7 @@ def findAllApproveAlert(request, tab):
 
 	#get permission with position login
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
 
         permiss = BasePermission.objects.filter(codename ='CAAPO')
         isPermiss_po = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename='CAAPO', branch_company__code__in = tab).values('branch_company__code')
@@ -797,7 +826,7 @@ def findAllApproveAlert(request, tab):
 	########################################
 	#ผู้ตรวจสอบ
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
         permiss = BasePermission.objects.filter(codename__in= ['CAECP1','CAECP2','CAECP3','CAECP4','CAECPD','CAECPA'])
         isPermissAE = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename__in= ['CAECP1','CAECP2','CAECP3','CAECP4','CAECPD','CAECPA']).prefetch_related(Prefetch('base_permission', queryset=permiss)).values('base_permission')
     except:
@@ -909,7 +938,7 @@ def findAllApproveAlert(request, tab):
 
     #ถ้าเป็นผู้อนุมัติพิเศษ ใบเปรียบเทียบ
     try:
-        user_profile = UserProfile.objects.get(user_id = request.user.id)
+        user_profile = _user_profile(request)
 
         permiss = BasePermission.objects.filter(codename ='CASCP')
         isPermiss_scp = PositionBasePermission.objects.filter(position_id = user_profile.position_id, base_permission__codename='CASCP', branch_company__code__in = tab).values('branch_company__code', 'base_permission')

--- a/stock/filters.py
+++ b/stock/filters.py
@@ -523,7 +523,9 @@ class AllDetailsFilter(django_filters.FilterSet):
     def filter_search(self, queryset, name, value):
         if not value:
             return queryset
-        q = (
+        # Forward-FK / local-column branches: a plain OR is safe here because
+        # every hop is to-one (single join, no row fan-out).
+        local_q = (
             Q(requisit__ref_no__icontains=value)
             | Q(requisit__ma_ref_no__icontains=value)
             | Q(requisit__pr_ref_no__icontains=value)
@@ -534,34 +536,51 @@ class AllDetailsFilter(django_filters.FilterSet):
             | Q(requisit__note__icontains=value)
             | Q(requisit__name__first_name__icontains=value)
             | Q(requisit__name__last_name__icontains=value)
-            | Q(comparisonpriceitem__bidder__cp__ref_no__icontains=value)
-            | Q(comparisonpriceitem__cp__in=ComparisonPrice.objects
-               .filter(ref_no__icontains=value).values('id'))
-            | Q(comparisonpriceitem__bidder__distributor__name__icontains=value)
-            | Q(purchaseorderitem__po__ref_no__icontains=value)
-            | Q(purchaseorderitem__po__cp__ref_no__icontains=value)
-            | Q(purchaseorderitem__po__pr__ref_no__icontains=value)
-            | Q(purchaseorderitem__po__distributor__name__icontains=value)
         )
-        return queryset.filter(q).distinct()
+        # Reverse-relation branches (comparison items / PO items): fold into
+        # EXISTS subqueries instead of LEFT JOINs. Previously these joins made
+        # the base queryset emit one row per comparison-item x PO-item, which
+        # forced SELECT DISTINCT + a filesort over the exploded join and was
+        # then re-run ~12x per request (paginator count + every dashboard
+        # aggregate). The EXISTS form returns the identical set of rows.
+        cpi_match = ComparisonPriceItem.objects.filter(
+            Q(bidder__cp__ref_no__icontains=value)
+            | Q(cp__in=ComparisonPrice.objects
+                .filter(ref_no__icontains=value).values('id'))
+            | Q(bidder__distributor__name__icontains=value),
+            item=OuterRef('pk'),
+        )
+        poi_match = PurchaseOrderItem.objects.filter(
+            Q(po__ref_no__icontains=value)
+            | Q(po__cp__ref_no__icontains=value)
+            | Q(po__pr__ref_no__icontains=value)
+            | Q(po__distributor__name__icontains=value),
+            item=OuterRef('pk'),
+        )
+        return queryset.filter(
+            local_q | Q(Exists(cpi_match)) | Q(Exists(poi_match))
+        ).distinct()
 
     def filter_stage(self, queryset, name, value):
         """Match the row's *deepest* reached stage, mirroring _all_details_rows:
         cancelled PurchaseOrder / ComparisonPrice do not count."""
         active_cp = ComparisonPrice.objects.filter(is_cancel=False).values('id')
-        has_po = Q(purchaseorderitem__isnull=False,
-                   purchaseorderitem__po__is_cancel=False)
-        has_cp = Q(comparisonpriceitem__isnull=False,
-                   comparisonpriceitem__cp__in=active_cp)
-        has_pr = Q(requisit__purchaserequisition__isnull=False)
+        # EXISTS subqueries rather than reverse-relation JOINs + DISTINCT: same
+        # membership test, no row fan-out.
+        has_po = Q(Exists(PurchaseOrderItem.objects.filter(
+            item=OuterRef('pk'), po__is_cancel=False)))
+        has_cp = Q(Exists(ComparisonPriceItem.objects.filter(
+            item=OuterRef('pk'), cp__in=active_cp)))
+        has_pr = Q(Exists(PurchaseRequisition.objects.filter(
+            requisition=OuterRef('requisit_id'))))
         if value == 'PO':
-            return queryset.filter(has_po).distinct()
+            return queryset.filter(has_po)
         if value == 'CP':
-            return queryset.filter(has_cp).exclude(has_po).distinct()
+            return queryset.filter(has_cp).exclude(has_po)
         if value == 'PR':
-            return queryset.filter(has_pr).exclude(has_cp).exclude(has_po).distinct()
+            return queryset.filter(has_pr).exclude(has_cp).exclude(has_po)
         if value == 'RQ':
-            return queryset.exclude(has_pr).exclude(has_cp).exclude(has_po).distinct()
+            return queryset.exclude(has_pr).exclude(has_cp).exclude(has_po)
         return queryset
 
 

--- a/stock/views.py
+++ b/stock/views.py
@@ -5252,8 +5252,34 @@ def viewAllDetailsReport(request):
 
 
 def _all_details_dashboard(qs):
-    item_ids = qs.values('id')
-    req_ids = qs.values('requisit_id')
+    # Ordering is meaningless inside an IN-subquery, and keeping it makes Django
+    # drag the ORDER BY column into the DISTINCT select list
+    # (SELECT DISTINCT RequisitionItem.id, Requisition.ref_no) — a wider sort
+    # plus a Requisition join, repeated in every subquery below. Strip it once.
+    lean = qs.order_by()
+    # Every aggregate below scopes on the filtered item ids. Handing them the
+    # queryset makes the database re-run (and re-materialise) that whole
+    # filtered subquery once per aggregate — 7x per page load — and with a
+    # search term that subquery is the expensive part. Pull the ids once and
+    # pass a plain list instead. Above the cap an IN-list would get unwieldy,
+    # but a result set that large only comes from a broad/unfiltered query,
+    # where the subquery is cheap anyway — so fall back to it there.
+    ID_CAP = 5000
+    pairs = list(lean.values_list('id', 'requisit_id')[:ID_CAP + 1])
+    if len(pairs) > ID_CAP:
+        item_ids = lean.values('id')
+        req_ids = lean.values('requisit_id')
+        ri_agg = lean.values('id', 'requisit_id').aggregate(
+            requisition_items=Count('id', distinct=True),
+            requisitions=Count('requisit_id', distinct=True),
+        )
+    else:
+        item_ids = [pk for pk, _ in pairs]
+        # NULL requisit_id is dropped: `x IN (.., NULL)` never matches anyway,
+        # and Count('requisit_id', distinct=True) likewise ignores NULLs.
+        req_ids = sorted({rq for _, rq in pairs if rq is not None})
+        ri_agg = {'requisition_items': len(item_ids),
+                  'requisitions': len(req_ids)}
     cancelled_cp = ComparisonPrice.objects.filter(is_cancel=True).values('id')
     cpi = (ComparisonPriceItem.objects
            .filter(item_id__in=item_ids)
@@ -5283,9 +5309,15 @@ def _all_details_dashboard(qs):
         except ValueError:
             continue
     # Money totals: PurchaseOrder header (deduped, non-cancelled) ...
+    # EXISTS rather than a reverse join + .distinct(): the join emitted one row
+    # per PO item, and .distinct() then forced Django to wrap the aggregate in a
+    # `SELECT DISTINCT <every PurchaseOrder column>` subquery just to dedupe the
+    # headers back down. EXISTS keeps one row per PO to begin with, so the sums
+    # are taken straight off the table.
+    has_scoped_item = Exists(PurchaseOrderItem.objects
+                             .filter(po=OuterRef('pk'), item_id__in=item_ids))
     po_money = (PurchaseOrder.objects
-                .filter(purchaseorderitem__item_id__in=item_ids, is_cancel=False)
-                .distinct()
+                .filter(has_scoped_item, is_cancel=False)
                 .aggregate(total_price=Sum('total_price'),
                            total_after_discount=Sum('total_after_discount'),
                            vat=Sum('vat'),
@@ -5293,14 +5325,16 @@ def _all_details_dashboard(qs):
     # ... plus the selected ComparisonPriceDistributor for comparisons that
     # stand on their own (a CP-stage row: not the source of any scoped PO).
     scoped_po_cp_ids = (PurchaseOrder.objects
-                        .filter(purchaseorderitem__item_id__in=item_ids,
+                        .filter(has_scoped_item,
                                 is_cancel=False, cp__isnull=False)
                         .values('cp'))
     cpd_money = (ComparisonPriceDistributor.objects
-                 .filter(comparisonpriceitem__item_id__in=item_ids, is_select=True)
+                 .filter(Exists(ComparisonPriceItem.objects
+                                .filter(bidder=OuterRef('pk'),
+                                        item_id__in=item_ids)),
+                         is_select=True)
                  .exclude(cp__is_cancel=True)
                  .exclude(cp__in=scoped_po_cp_ids)
-                 .distinct()
                  .aggregate(total_price=Sum('total_price'),
                             total_after_discount=Sum('total_after_discount'),
                             vat=Sum('vat'),
@@ -5311,15 +5345,15 @@ def _all_details_dashboard(qs):
 
     tp = _tot('total_price')
     tad = _tot('total_after_discount')
-    ri_agg = qs.aggregate(
-        requisition_items=Count('id', distinct=True),
-        requisitions=Count('requisit_id', distinct=True),
-    )
     return {
         'requisitions': ri_agg['requisitions'],
         'requisition_items': ri_agg['requisition_items'],
+        # .values('id') keeps the DISTINCT on the PK instead of on every column
+        # of the table (the filter is on a local column, so no row can be
+        # duplicated and the two forms count the same set).
         'purchase_reqs': (PurchaseRequisition.objects
-                          .filter(requisition_id__in=req_ids).distinct().count()),
+                          .filter(requisition_id__in=req_ids)
+                          .values('id').distinct().count()),
         'comparison_prices': cp_agg['comparison_prices'],
         'comparison_items': cp_agg['comparison_items'],
         'distributors': cp_agg['distributors'],


### PR DESCRIPTION
@
## สรุป
ปรับหน้า view all detail (RQ/PR/CM/PO) ให้โหลดเร็วขึ้น โดยปรับ query และ filter

## ไฟล์ที่แก้ไข
- `stock/context_processors.py`
- `stock/filters.py`
- `stock/views.py`

## การทดสอบ
- `python manage.py test` — ผ่านทั้งหมด 88 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@