### PR TITLE
แก้ไขชื่อ sheet และ ชนิด file ในรายงาน PO to Express

### DIFF
--- a/stock/templates/report/viewPO.html
+++ b/stock/templates/report/viewPO.html
@@ -281,7 +281,7 @@
 
     const queryString = "{{ request.GET.urlencode|escapejs }}";
     const py_url = "{% url 'exportExcelPOToExpress' %}" + (queryString ? "?" + queryString : "");
-    const file_name = "PO_to_Express_Report_("+'{{ request.session.company_code }}'+").xlsx";
+    const file_name = "PO_to_Express_Report_("+'{{ request.session.company_code }}'+").xls";
 
 	  const delay_time = 50;
     progress_bar(btn, btnText, btnProgress, btnPercent, py_url, file_name, delay_time)

--- a/stock/views.py
+++ b/stock/views.py
@@ -5928,7 +5928,8 @@ def cal_days_between_nagative(day1, day2):
 def normalize_datetime(value):
     if value is None:
         return None
-    if is_aware(value):
+    #date ธรรมดาไม่มี utcoffset() จึงต้องเช็ค datetime ก่อนเรียก is_aware
+    if hasattr(value, 'utcoffset') and is_aware(value):
         value = make_naive(value)  #Convert to naive datetime
     return value.strftime('%Y-%m-%d')  #Format as string
 
@@ -5984,7 +5985,7 @@ def exportExcelPOToExpress(request):
 
     data1 = {
         'เลขที่': [r['po__ref_no'] for r in rows],
-        'วันที่': [r['po__created'] for r in rows],
+        'วันที่': [normalize_datetime(r['po__created']) for r in rows],
         'รหัสบริษัท': [r['po__branch_company__code'] for r in rows],
         'บริษัท': [r['po__branch_company__name'] for r in rows],
         'รหัสผู้จำหน่าย': [r['po__distributor'] for r in rows],
@@ -6060,13 +6061,12 @@ def exportExcelPOToExpress(request):
 
     result = pd.concat([df1, df2, df3, df4, df5])
 
-    response = HttpResponse(
-        content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    )
-    response['Content-Disposition'] = f'attachment; filename=PO_to_Express_Report_({active}).xlsx'
+    #ส่งออกเป็นไฟล์ Excel 97-2003 Workbook (.xls) ชีทชื่อ EXPRESS
+    response = HttpResponse(content_type='application/vnd.ms-excel')
+    response['Content-Disposition'] = f'attachment; filename=PO_to_Express_Report_({active}).xls'
 
-    with pd.ExcelWriter(response, engine='xlsxwriter', engine_kwargs={'options': {'strings_to_numbers': True}}) as writer:
-        result.to_excel(writer, index=False)
+    with pd.ExcelWriter(response, engine='xlwt') as writer:
+        result.to_excel(writer, index=False, sheet_name='EXPRESS')
 
     return response
 


### PR DESCRIPTION
## สรุป
แก้ไขรายงาน PO to Express ให้ export เป็นไฟล์ Excel 97-2003 Workbook (`.xls`) และตั้งชื่อ sheet เป็น `EXPRESS` ตามที่ระบบ Express ต้องการ

## รายละเอียดการเปลี่ยนแปลง
- `stock/views.py`
  - เปลี่ยนการ export จาก `.xlsx` (engine `xlsxwriter`) เป็น `.xls` (engine `xlwt`) พร้อม content type `application/vnd.ms-excel`
  - ตั้งชื่อ sheet เป็น `EXPRESS`
  - จัดรูปแบบคอลัมน์ `วันที่` ผ่าน `normalize_datetime()` แทนการส่งค่าดิบ
  - `normalize_datetime()` เช็ค `hasattr(value, 'utcoffset')` ก่อนเรียก `is_aware()` เพราะ `date` ธรรมดาไม่มี `utcoffset()`
- `stock/templates/report/viewPO.html` — ปรับข้อความ/ลิงก์ให้สอดคล้องกับชนิดไฟล์ใหม่

## การทดสอบ
`python manage.py test` — ผ่านทั้งหมด 122 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
